### PR TITLE
Streamline/trim down Python getting started page

### DIFF
--- a/getting-started/editor/index.md
+++ b/getting-started/editor/index.md
@@ -1,4 +1,4 @@
-# openEO Platform Editor
+# Get started with the openEO Platform Editor
 
 ::: tip Note
 You need to [become part of the openEO Platform "early adopter" program](https://openeo.cloud/#adopters) to access the processing infrastructure.

--- a/getting-started/javascript/index.md
+++ b/getting-started/javascript/index.md
@@ -1,4 +1,4 @@
-# JavaScript Client
+# Get started with the openEO JavaScript Client
 
 ::: tip Note
 You need to [become part of the openEO Platform "early adopter" program](https://openeo.cloud/#adopters) to access the processing infrastructure.

--- a/getting-started/jupyterlab/index.md
+++ b/getting-started/jupyterlab/index.md
@@ -1,4 +1,4 @@
-# Get started with openEO in JupyterLab (Python)
+# Get started with openEO Platform in JupyterLab (Python)
 
 ::: tip Note
 You need to [become part of the openEO Platform "early adopter" program](https://openeo.cloud/#adopters) to access the processing infrastructure.

--- a/getting-started/jupyterlab/index.md
+++ b/getting-started/jupyterlab/index.md
@@ -1,4 +1,4 @@
-# JupyterLab (Python)
+# Get started with openEO in JupyterLab (Python)
 
 ::: tip Note
 You need to [become part of the openEO Platform "early adopter" program](https://openeo.cloud/#adopters) to access the processing infrastructure.

--- a/getting-started/python/index.md
+++ b/getting-started/python/index.md
@@ -1,4 +1,4 @@
-# Get started with openEO Python Client
+# Get started with the openEO Python Client
 
 ::: tip Note
 You need to [become part of the openEO Platform "early adopter" program](https://openeo.cloud/#adopters) to access the processing infrastructure.
@@ -56,25 +56,29 @@ More information on how openEO "collections" relate to terminology used in other
 
 While it's recommended to browse the available EO collections on the  
 [openEO Platform collections overview webpage](../../data-collections/index.md),
-it's possible to list and inspect them programmatically, 
-as very simple example of openEO Python client usage,
-using methods on the `connection` object we just created 
-(like [`list_collection_ids`](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.connection.Connection.list_collection_ids))
-or [`describe_collection`](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.connection.Connection.describe_collection)):
+it's possible to list and inspect them programmatically.
+As a very simple usage example of openEO Python client,
+let's use the
+[`list_collection_ids`](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.connection.Connection.list_collection_ids)
+and [`describe_collection`](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.connection.Connection.describe_collection)
+methods on the `connection` object we just created: 
 
 ```
 >>> # Get all collection ids
 >>> print(connection.list_collection_ids())
 ['AGERA5', 'SENTINEL1_GRD', 'SENTINEL2_L2A', ...
 
->>> # Get a listing of all collections with metadata
->>> print(connection.list_collections())
-[{'id': 'AGERA5', 'title': 'ECMWF AGERA5 meteo dataset ...', 'description': ...
-
 >>> # Get metadata of a single collection
 >>> print(connection.describe_collection("SENTINEL2_L2A"))
 {'id': 'SENTINEL2_L2A', 'title': 'Sentinel-2 top of canopy ...', 'stac_version': '0.9.0', ...
 ```
+
+::: tip
+The openEO Python client library comes with Jupyter (notebook) integration in a couple of places.
+For example, put `connection.describe_collection("SENTINEL2_L2A")` (without `print()`)
+as last statement in a notebook cell 
+and you'll get a nice graphical rendering of the collection metadata.
+:::
 
 
 ::: tip
@@ -108,8 +112,10 @@ with [`list_processes`](https://open-eo.github.io/openeo-python-client/api.html#
  ...
 ```
 
-Like with collections, instead of programmatic exploration you'll probably prefer a 
-[web-based overview of the available processes on openEO Platform](../../processes/index.md).
+Like with collections, instead of programmatic exploration you'll probably prefer a
+more graphical, interactive interface.
+Use the Jupyter notebook integration (put `connection.list_processes()` without `print()` as last statement in a notebook cell)
+or visit a [web-based overview of the available processes on openEO Platform](../../processes/index.md).
 
 ::: tip
 Find out more about process discovery and usage
@@ -143,7 +149,7 @@ Otherwise, e.g. the first time you do this, some user interaction is required
 and it will print a web link and a short _user code_.
 Visit this web page in a browser, log in there with an existing account and enter the user code.
 If everything goes well, the `connection` object in the script will be authenticated
-and the back-end will be able to identify you from subsequent requests.
+and the back-end will be able to identify you in subsequent requests.
 
 More detailed information on authentication can be found
 [in the openEO Python client documentation](https://open-eo.github.io/openeo-python-client/auth.html).

--- a/getting-started/python/index.md
+++ b/getting-started/python/index.md
@@ -72,7 +72,7 @@ or [`describe_collection`](https://open-eo.github.io/openeo-python-client/api.ht
 [{'id': 'AGERA5', 'title': 'ECMWF AGERA5 meteo dataset ...', 'description': ...
 
 >>> # Get metadata of a single collection
->>> print(connection.describe_collection())
+>>> print(connection.describe_collection("SENTINEL2_L2A"))
 {'id': 'SENTINEL2_L2A', 'title': 'Sentinel-2 top of canopy ...', 'stac_version': '0.9.0', ...
 ```
 

--- a/getting-started/python/index.md
+++ b/getting-started/python/index.md
@@ -1,4 +1,4 @@
-# Python Client
+# Get started with openEO Python Client
 
 ::: tip Note
 You need to [become part of the openEO Platform "early adopter" program](https://openeo.cloud/#adopters) to access the processing infrastructure.
@@ -9,8 +9,7 @@ More in-depth information can be found in its [official documentation](https://o
 
 ## Installation
 
-The openEO Python client library is available on [PyPI](https://pypi.org/project/openeo/)
-and can easily be installed with a tool like `pip`, for example:
+The openEO Python client library can easily be installed with a tool like `pip`, for example:
 
 ```shell script
 pip install openeo
@@ -27,8 +26,7 @@ see the [official ``openeo`` package installation documentation](https://open-eo
 
 ## Connect to openEO Platform and explore
 
-First we need to establish a connection to the openEO Platform back-end, 
-which is available at connection URL `https://openeo.cloud`, or just in short:
+First, establish a connection to the openEO Platform back-end:
 
 ```python
 import openeo
@@ -46,10 +44,9 @@ is your central gateway to
 
 ### Collections
 
-The EO data available at a back-end is organised in so-called collections.
-For example, a back-end might provide fundamental satellite collections like "Sentinel 1" or "Sentinel 2",
+The Earth observation data (the input of your openEO jobs) is organised in so-called collections,
+e.g. fundamental satellite collections like "Sentinel 1" or "Sentinel 2",
 or preprocessed collections like "NDVI".
-Collections are used as input data for your openEO jobs.
 
 ::: tip Note
 More information on how openEO "collections" relate to terminology used in other systems can be found in
@@ -57,31 +54,32 @@ More information on how openEO "collections" relate to terminology used in other
 :::
 
 
-Let's list all available collections on the back-end,
-using [`list_collections`](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.connection.Connection.list_collections):
+While it's recommended to browse the available EO collections on the  
+[openEO Platform collections overview webpage](../../data-collections/index.md),
+it's possible to list and inspect them programmatically, 
+as very simple example of openEO Python client usage,
+using methods on the `connection` object we just created 
+(like [`list_collection_ids`](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.connection.Connection.list_collection_ids))
+or [`describe_collection`](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.connection.Connection.describe_collection)):
 
-```python
-print(connection.list_collections())
+```
+>>> # Get all collection ids
+>>> print(connection.list_collection_ids())
+['AGERA5', 'SENTINEL1_GRD', 'SENTINEL2_L2A', ...
+
+>>> # Get a listing of all collections with metadata
+>>> print(connection.list_collections())
+[{'id': 'AGERA5', 'title': 'ECMWF AGERA5 meteo dataset ...', 'description': ...
+
+>>> # Get metadata of a single collection
+>>> print(connection.describe_collection())
+{'id': 'SENTINEL2_L2A', 'title': 'Sentinel-2 top of canopy ...', 'stac_version': '0.9.0', ...
 ```
 
-which returns list of collection metadata dictionaries, e.g. something like:
-
-```
-[{'id': 'AGERA5', 'title': 'ECMWF AGERA5 meteo dataset', 'description': 'Daily surface meteorolociga datal ...', ...},
- {'id': 'SENTINEL2_L2A_SENTINELHUB', 'title': 'Sentinel-2 top of canopy', ...},
- {'id': 'SENTINEL1_GRD', ...},
- ...]
-```
-
-This listing includes basic metadata for each collection.
-If necessary, a more detailed metadata listing for a given collection can be obtained with
-[`describe_collection`](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.connection.Connection.describe_collection).
 
 ::: tip
-Programmatically listing collections is just a very simple usage example of the Python client.
-In reality, you probably want to look up or inspect available collections on handy webpage. 
-Check out the [openEO Platform collections overview](../../data-collections/index.md)
-or the [openEO Hub](https://hub.openeo.org/) for collection listings of other back-ends.
+Find out more about data discovery, loading and filtering in the
+[official openEO Python client documentation](https://open-eo.github.io/openeo-python-client/data_access.html)
 :::
 
 
@@ -91,8 +89,8 @@ or the [openEO Hub](https://hub.openeo.org/) for collection listings of other ba
 Processes in openEO are operations that can be applied on (EO) data
 (e.g. calculate the mean of an array, or mask out observations outside a given polygon).
 The output of one process can be used as the input of another process,
-and by doing so, multiple processes can be connected that way in a larger "process graph":
-a new (user-defined) processes that implements a certain algorithm.
+and by doing so, multiple processes can be connected that way in a larger "process graph"
+that implements a certain algorithm.
 
 ::: tip Note
 Check [the openEO glossary](https://openeo.org/documentation/1.0/glossary.html#processes)
@@ -100,29 +98,28 @@ for more details on pre-defined, user-defined processes and process graphs.
 :::
 
 
-Let's list the (pre-defined) processes available on the back-end
+Let's list the available pre-defined processes 
 with [`list_processes`](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.connection.Connection.list_processes):
 
-```python
-print(connection.list_processes())
 ```
-
-which returns a list of dictionaries describing the process (including expected arguments and return type), e.g.: 
-
-```
-[{'id': 'absolute', 'summary': 'Absolute value', 'description': 'Computes the absolute value of a real number `x`, which is th...', 
- {'id': 'mean', 'summary': 'Arithmetic mean(average)', ...}
- ...]
+>>> print(connection.list_processes())
+[{'id': 'absolute', 'summary': 'Absolute value', 'description': 'Computes the absolute value of ... 
+ {'id': 'mean', 'summary': 'Arithmetic mean(average)', ...
+ ...
 ```
 
 Like with collections, instead of programmatic exploration you'll probably prefer a 
 [web-based overview of the available processes on openEO Platform](../../processes/index.md).
-You can also use the [openEO Hub](https://hub.openeo.org/) for back-end specific process descriptions
-or browse the [reference specifications of openEO processes](https://processes.openeo.org/).
+
+::: tip
+Find out more about process discovery and usage
+[official openEO Python client documentation](https://open-eo.github.io/openeo-python-client/processes.html)
+:::
+
 
 ## Authentication
 
-In the code snippets above we did not need to log in
+In the code snippets above we did not need to log in as a user
 since we just queried publicly available back-end information.
 However, to run non-trivial processing queries one has to authenticate
 so that permissions, resource usage, etc. can be managed properly.
@@ -130,36 +127,33 @@ so that permissions, resource usage, etc. can be managed properly.
 To handle authentication, openEO leverages [OpenID Connect (OIDC)](https://openid.net/connect/).
 It offers some interesting features (e.g. a user can securely reuse an existing account),
 but is a fairly complex topic, discussed in more depth in the general for the
-[Free Tier](../../join/free_tier.md) and the [Early Adopter program](../../join/early_adopter.md).
+[Free Tier](../../join/free_trial.md) and the [Early Adopter program](../../join/early_adopter.md).
 
 The openEO Python client library tries to make authentication as streamlined as possible.
-For example, the following snippet illustrates how you can authenticate
-from a Python script or notebook:
-
-```python
-connection.authenticate_oidc()
-```
-
-This statement will reuse a previously authenticated session, when available, 
-and otherwise print a web link and a short user code because user interaction is required.
-After successfully visiting the web link in a browser, authenticating there and entering the user code, 
-the connection in the script will also be authenticated.
-This means that subsequent requests from the `connection` object will 
-be properly identified by the back-end as coming from your user.
+In most cases for example, the following snippet is enough to obtain an authenticated connection:
 
 ```python
 import openeo
+
 connection = openeo.connect("openeo.cloud").authenticate_oidc()
 ```
 
+This statement will automatically reuse a previously authenticated session, when available.
+Otherwise, e.g. the first time you do this, some user interaction is required
+and it will print a web link and a short _user code_.
+Visit this web page in a browser, log in there with an existing account and enter the user code.
+If everything goes well, the `connection` object in the script will be authenticated
+and the back-end will be able to identify you from subsequent requests.
+
 More detailed information on authentication can be found
-[here](https://open-eo.github.io/openeo-python-client/auth.html#openid-connect-based-authentication).
+[in the openEO Python client documentation](https://open-eo.github.io/openeo-python-client/auth.html).
+
 
 ## Working with Datacubes
 
 Now that we know how to discover the capabilities of the back-end and how to authenticate, 
 let's do some real work and process some EO data in a batch job.
-We'll build the desired algorithm by working on so-called "Datacubes", 
+We'll first build the desired algorithm by working on so-called "Datacubes", 
 which is the central concept in openEO to represent EO data, 
 as [discussed in great detail here](https://openeo.org/documentation/1.0/datacubes.html).
 
@@ -178,34 +172,19 @@ datacube = connection.load_collection(
 )
 ```
 
-This results in a [`Datacube` object](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.datacube.DataCube) 
-containing the "SENTINEL1_GRD" data restricted to the given spatial extent, 
-the given temporal extend and the given bands .
-
-::: tip
-You can also filter the datacube step by step or at a later stage by using the following filter methods:
-
-```python
-datacube = datacube.filter_bbox(west=16.06, south=48.06, east=16.65, north=48.35)
-datacube = datacube.filter_temporal(start_date="2017-03-01", end_date="2017-04-01")
-datacube = datacube.filter_bands(["VV", "VH"])
-```
-
-Still, it is recommended to always use the filters directly in [load_collection](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.connection.Connection.load_collection)
-to avoid loading too much data upfront.
-:::
+This results in a [`DataCube` object](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.datacube.DataCube) 
+containing the "SENTINEL1_GRD" data restricted to the given spatial extent, temporal extent and bands.
 
 
 ### Applying processes
 
 By applying an openEO process on a datacube, we create a new datacube object that represents the manipulated data.
-The standard way to do this with the Python client is to call the appropriate [`Datacube` object](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.datacube.DataCube) method.
-The most common or popular openEO processes have a dedicated `Datacube` method (e.g. `mask`, `aggregate_spatial`, `filter_bbox`, ...). 
-Other processes without a dedicated method can still be applied in a generic way.
-An on top of that, there are also some convenience methods that implement
-openEO processes is a compact, Pythonic interface.
+The openEO Python client allows to do this by calling [`DataCube` object methods](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.datacube.DataCube).
+The most common or popular openEO processes have a dedicated `DataCube` method (e.g. `mask`, `aggregate_spatial`, `filter_bbox`, ...). 
 
-For example, the [`min_time`](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.datacube.DataCube.min_time) method
+There are also some convenience methods that implement
+more complex openEO processes constructs is a compact, Pythonic interface.
+For example, the [`DataCube.min_time`](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.datacube.DataCube.min_time) method
 implements a `reduce_dimension` process along the temporal dimension, using the `min` process as reducer function:
 
 ```python
@@ -216,10 +195,11 @@ This creates a new datacube (we overwrite the existing variable),
 where the time dimension is eliminated and for each pixel we just have 
 the minimum value of the corresponding timeseries in the original datacube.
 
-See the [Python client `Datacube` API](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.datacube.DataCube) for a more complete listing of methods that implement openEO processes.
+See the [Python client's `DataCube` API documentation](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.datacube.DataCube) 
+for a more complete listing of methods that implement openEO processes.
 
 
-openEO processes that are not supported by a dedicated `Datacube` method
+openEO processes that are not supported by a dedicated `DataCube` method
 can be applied in a generic way with the [`process` method](https://open-eo.github.io/openeo-python-client/api.html#openeo.rest.datacube.DataCube.process), e.g.:
 
 ```python
@@ -253,8 +233,8 @@ result = datacube.save_result("GTiff")
 It's important to note that all the datacube processes we applied up to this point
 are not actually executed yet, neither locally nor remotely on the back-end.
 We just built an abstract representation of the algorithm (input data and processing chain), 
-encapsulated in a local `Datacube` object (e.g. the `result` variable above).
-To trigger an actual execution (on the back-end) we have to explicitly send this representation 
+encapsulated in a local `DataCube` object (e.g. the `result` variable above).
+To trigger actual execution on the back-end we have to explicitly send this representation 
 to the back-end.
 
 
@@ -277,7 +257,7 @@ If you want to use an interface for your batch jobs (or other resources) that is
 After login, you'll be able to manage and monitor your batch jobs in a near-realtime interactive environment; Look out for the "Data Processing" tab. 
 :::
 
-The batch job, which is referenced by the returned `job` object, is just created at the back-end, 
+The batch job, which is referenced by the returned `job` object, is only _created_ at the back-end, 
 it is not started yet.
 To start the job and let your Python script wait until the job has finished then 
 download it automatically, you can use the `start_and_wait` method. 
@@ -301,8 +281,8 @@ or [more detailed batch job (result) management](https://open-eo.github.io/opene
 
 Additional information and resources about the openEO Python Client Library:
 
-* [Official openeo.cloud sample notebooks](https://github.com/openEOPlatform/sample-notebooks)
-* [Example scripts](https://github.com/Open-EO/openeo-python-client/tree/master/examples)
-* [Example Jupyter Notebooks](https://github.com/Open-EO/openeo-python-client/tree/master/examples/notebooks)
 * [Official openEO Python Client Library Documentation](https://open-eo.github.io/openeo-python-client/)
+* [Official openeo.cloud sample notebooks](https://github.com/openEOPlatform/sample-notebooks)
+* [Example Python scripts](https://github.com/Open-EO/openeo-python-client/tree/master/examples)
+* [Example Jupyter Notebooks](https://github.com/Open-EO/openeo-python-client/tree/master/examples/notebooks)
 * [Repository on GitHub](https://github.com/Open-EO/openeo-python-client)

--- a/getting-started/r/index.md
+++ b/getting-started/r/index.md
@@ -1,4 +1,4 @@
-# R Client
+# Get started with the openEO R Client
 
 ::: tip Note
 You need to [become part of the openEO Platform "early adopter" program](https://openeo.cloud/#adopters) to access the processing infrastructure.


### PR DESCRIPTION
as discussed under  openEOPlatform/architecture-docs#232: 
simplify getting started with Python client, and push users more to official docs.

Also various small (typo) fixes


feel free to cherry pick