### PR TITLE
Python getting started: remove stale batch job doc link

### DIFF
--- a/getting-started/python/index.md
+++ b/getting-started/python/index.md
@@ -284,8 +284,7 @@ in a folder "output".
 
 ::: tip
 The official openEO Python Client documentation has more information
-on [batch job basics](https://open-eo.github.io/openeo-python-client/basics.html#managing-jobs-in-openeo) 
-or [more detailed batch job (result) management](https://open-eo.github.io/openeo-python-client/batch_jobs.html)
+on [batch job management and downloading results](https://open-eo.github.io/openeo-python-client/batch_jobs.html)
 :::
 
 ## Additional Information


### PR DESCRIPTION
remove deep link to batch job docs that became stale after rework of "getting started" doc https://open-eo.github.io/openeo-python-client/basics.html  under https://github.com/Open-EO/openeo-python-client/issues/308