### PR TITLE
add on-demand-preview documentation

### DIFF
--- a/federation/index.md
+++ b/federation/index.md
@@ -144,6 +144,18 @@ click the '*sign in*' menu item at the top, and pick the *'EduGAIN and social lo
 After a one-time registration process, you should have access to all Terrascope services
 using your institution or (social) platform credentials.
 
+## On-demand-preview
+
+Sometimes there is the need for a quick inspections of the results from a process graph on the map without running the whole graph first and having to wait for results to be computed and returned. This `on-demand-preview` is both available in the openEO Platform Editor as well as in the openEO Python Client.
+
+In the Editor you can find the functionality in the `Web Services` tab. Use the button `Show on Map`. To use this functionaliy in the Python Client you can call `.preview()` on your datacube and display it in an Ipyleaflet widget via `preview, service = datacube.preview`.
+
+::: tip Note
+This functionallity currently only works with collections that are also on the Sentinel Hub backend. In order for the map to be able to display meaningful results your process graph should:
+- return one or three bands, 
+- one single temporal extent,
+- and scale the data to a range so the output format can adequately save it.
+:::
 
 ## Batch jobs
 

--- a/federation/index.md
+++ b/federation/index.md
@@ -148,7 +148,7 @@ using your institution or (social) platform credentials.
 
 Sometimes there is the need for a quick inspections of the results from a process graph on the map without running the whole graph first and having to wait for results to be computed and returned. This `on-demand-preview` is both available in the openEO Platform Editor as well as in the openEO Python Client.
 
-In the Editor you can find the functionality in the `Web Services` tab. Use the button `Show on Map`. To use this functionaliy in the Python Client you can call `.preview()` on your datacube and display it in an Ipyleaflet widget via `preview, service = datacube.preview`.
+In the Editor you can find the functionality in the `Web Services` tab. Use the button `Show on Map`. To use this functionaliy in the Python Client you can call `.preview()` on your datacube and display it in an Ipyleaflet widget via `preview, service = datacube.preview()`.
 
 ::: tip Note
 This functionallity currently only works with collections that are also on the Sentinel Hub backend. In order for the map to be able to display meaningful results your process graph should:

--- a/federation/index.md
+++ b/federation/index.md
@@ -146,12 +146,12 @@ using your institution or (social) platform credentials.
 
 ## On-demand-preview
 
-Sometimes there is the need for a quick inspections of the results from a process graph on the map without running the whole graph first and having to wait for results to be computed and returned. This `on-demand-preview` is both available in the openEO Platform Editor as well as in the openEO Python Client.
+Sometimes there is the need for a quick inspections of the results from a process graph on the map without running the whole graph first and having to wait for results to be computed and returned. This `on-demand-preview` is available in the [openEO Platform Editor](https://editor.openeo.cloud/).
 
-In the Editor you can find the functionality in the `Web Services` tab. Use the button `Show on Map`. To use this functionaliy in the Python Client you can call `.preview()` on your datacube and display it in an Ipyleaflet widget via `preview, service = datacube.preview()`.
+In the Editor you can find the functionality in the `Web Services` tab. Use the button `Show on Map`.
 
 ::: tip Note
-This functionallity currently only works with collections that are also on the Sentinel Hub backend. In order for the map to be able to display meaningful results your process graph should:
+This functionallity currently only works with collections that are also on the Sentinel Hub backend (Provider > Backend > sentinelhub). In order for the map to be able to display meaningful results your process graph should:
 - return one or three bands, 
 - one single temporal extent,
 - and scale the data to a range so the output format can adequately save it.


### PR DESCRIPTION
Draft documentation for on-demand preview functionality. Probably makes sense to have the python client documentation in the library somewhere and then only link to it from here.