### PR TITLE
remove early adopter from navigation, it no longer exists

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -24,7 +24,6 @@ module.exports = {
           { text: 'JupyterLab (Python)', link: '/getting-started/jupyterlab/' },
           { text: 'Editor', link: '/getting-started/editor/' }
         ] },
-        { text: 'Early Adopter Registration', link: '/join/early_adopter.html' },
         { text: 'Free Trial Registration', link: '/join/free_trial.html' }, 
         { text: 'Cookbook', link: 'https://openeo.org/documentation/1.0/cookbook/' },
       ] },

--- a/.vuepress/enhanceApp.js
+++ b/.vuepress/enhanceApp.js
@@ -4,7 +4,8 @@ export default ({ router, Vue }) => {
 	];
 	router.beforeEach((to, from, next) => {
 	  const redirectList = {
-		'/authentication': '/join/early_adopter.html',
+		'/authentication': '/join/free_trial.html',
+		'/join/early_adopter.html': '/join/free_trial.html',
 	  }
 	  const redirect = redirectList[to.path]
   

--- a/getting-started/editor/index.md
+++ b/getting-started/editor/index.md
@@ -1,14 +1,14 @@
 # Get started with the openEO Platform Editor
 
 ::: tip Note
-You need to [become part of the openEO Platform "early adopter" program](https://openeo.cloud/#adopters) to access the processing infrastructure.
+To access the processing infrastructure you need an openEO Platform account. Read all about the service offering including our free trial offer [here](https://openeo.cloud/#plans).
 :::
 
 The *openEO Platform Editor* (also called *Web Editor*) is a browser-based graphical user interface for openEO Platform. It allows to use the openEO Platform services without any coding experience. You can explore the service offerings such as data collections and processes, but also create and run custom processes on our infrastructure and then visualize the results. Result visualization is still a bit limited, but all other features of the Platform are supported.
 
 The Editor is available at <https://editor.openeo.cloud> and loads up in "Discovery mode" by default, which means you can explore the service offerings without being logged in. On the left side you can find the service offerings like data collections and processes and on the right side the process editor is shown.
 
-To enable more functionality, e.g. to compute something in a batch job, you have to login. Hover over the button with the text "Guest" in the top right corner and it will show you a "Login" button. Once you clicked on it, the login screen shows up. Here you can simply click the "Log in with EGI Check-in" button and the login procedure will start. See the chapters on the [Free Tier](../../join/free_tier.md) or the [Early Adopter program](../../join/early_adopter.md) for more details on the procedure to register and log in.
+To enable more functionality, e.g. to compute something in a batch job, you have to login. Hover over the button with the text "Guest" in the top right corner and it will show you a "Login" button. Once you clicked on it, the login screen shows up. Here you can simply click the "Log in with EGI Check-in" button and the login procedure will start. See the chapters on the [Free Trial](../../join/free_trial.md) for more details on the procedure to register and log in.
 
 After you've completed this the login procedure, the Editor shows up again and you'll notice that a new area in the lower middle part of the Editor aprears. This is the user workspace, where you can see all your stored data, e.g. batch jobs or uploaded files.
 

--- a/getting-started/javascript/index.md
+++ b/getting-started/javascript/index.md
@@ -1,7 +1,7 @@
 # Get started with the openEO JavaScript Client
 
 ::: tip Note
-You need to [become part of the openEO Platform "early adopter" program](https://openeo.cloud/#adopters) to access the processing infrastructure.
+To access the processing infrastructure you need an openEO Platform account. Read all about the service offering including our free trial offer [here](https://openeo.cloud/#plans).
 :::
 
 ## Installation
@@ -173,7 +173,7 @@ If you have included the library using HTML `script` tags, then you need to incl
 No further action is required, if you have installed the client via npm.
 ::: 
 
-As OpenID Connect authentication is a bit more complex and depends on the environment your are using it in (e.g. Browser or Node), please refer to the  [JavaScript client documentation](https://open-eo.github.io/openeo-js-client/latest/OidcProvider.html) and the documentation to join the [Free Tier](../../join/free_tier.md) or the [Early Adopter program](../../join/early_adopter.md).
+As OpenID Connect authentication is a bit more complex and depends on the environment your are using it in (e.g. Browser or Node), please refer to the  [JavaScript client documentation](https://open-eo.github.io/openeo-js-client/latest/OidcProvider.html) and the documentation to join the [Free Trial](../../join/free_trial.md).
 
 ## Creating a (user-defined) process
 

--- a/getting-started/jupyterlab/index.md
+++ b/getting-started/jupyterlab/index.md
@@ -1,7 +1,7 @@
 # Get started with openEO Platform in JupyterLab (Python)
 
 ::: tip Note
-You need to [become part of the openEO Platform "early adopter" program](https://openeo.cloud/#adopters) to access the processing infrastructure.
+To access the processing infrastructure you need an openEO Platform account. Read all about the service offering including our free trial offer [here](https://openeo.cloud/#plans).
 :::
 
 A hosted JupyterLab environment for openEO Platform is available at **[lab.openeo.cloud](https://lab.openeo.cloud/)**.
@@ -11,7 +11,7 @@ It has the openEO Python client pre-installed, but it does not support running t
 You need to authenticate before you can use it:
 
 1. Click the "Sign in with EODC Identity Providers" button
-2. Now you need to select the "EGI" button on the right (instead of directly typing in your credentials on the left). It will start the EGI Authentication workflow for openEO Platform. For details check the documentation to join the [Free Tier](../../join/free_tier.md) or the [Early Adopter program](../../join/early_adopter.md).
+2. Now you need to select the "EGI" button on the right (instead of directly typing in your credentials on the left). It will start the EGI Authentication workflow for openEO Platform. For details check the documentation to join on our [Free Trial](../../join/free_trial.md) page.
 3. After you have logged in via EGI, the "Server Options" appear and you are requested to "Select your desired stack". Please choose "openEO Platform Lab" and click "Start".
 4. You are logged in, now. The JupyterLab should be usable like a normal JupyterLab instance that has the openEO Python client and some other tools pre-installed.
 5. You can now open a new Python 3 Notebook and, for example, start to follow the general [Python Getting Started Guide](../python/index.md).

--- a/getting-started/python/index.md
+++ b/getting-started/python/index.md
@@ -1,7 +1,7 @@
 # Get started with the openEO Python Client
 
 ::: danger Important
-You need to [become part of the openEO Platform "early adopter" program](https://openeo.cloud/#adopters) to access the processing infrastructure.
+To access the processing infrastructure you need an openEO Platform account. Read all about the service offering including our free trial offer [here](https://openeo.cloud/#plans).
 
 This Getting Started guide will simply give you an overview of the capabilities of the openEO Python client library.
 More in-depth information and documentation can be found on the [official documentation](https://open-eo.github.io/openeo-python-client/) website.
@@ -138,9 +138,8 @@ However, to run non-trivial processing queries one has to authenticate
 so that permissions, resource usage, etc. can be managed properly.
 
 To handle authentication, openEO leverages [OpenID Connect (OIDC)](https://openid.net/connect/).
-It offers some interesting features (e.g. a user can securely reuse an existing account),
-but is a fairly complex topic, discussed in more depth in the general for the
-[Free Tier](../../join/free_trial.md) and the [Early Adopter program](../../join/early_adopter.md).
+It offers some interesting features (e.g., a user can securely reuse an existing account),
+but is a fairly complex topic, discussed in more depth on the [Free Trial](../../join/free_trial.md) page.
 
 The openEO Python client library tries to make authentication as streamlined as possible.
 In most cases for example, the following snippet is enough to obtain an authenticated connection:

--- a/getting-started/r/index.md
+++ b/getting-started/r/index.md
@@ -1,7 +1,7 @@
 # Get started with the openEO R Client
 
 ::: tip Note
-You need to [become part of the openEO Platform "early adopter" program](https://openeo.cloud/#adopters) to access the processing infrastructure.
+To access the processing infrastructure you need an openEO Platform account. Read all about the service offering including our free trial offer [here](https://openeo.cloud/#plans).
 :::
 
 ## Useful links
@@ -129,9 +129,8 @@ However, to run non-trivial processing queries one has to authenticate
 so that permissions, resource usage, etc. can be managed properly.
 
 To handle authentication, openEO leverages [OpenID Connect (OIDC)](https://openid.net/connect/).
-It offers some interesting features (e.g. a user can securely reuse an existing account),
-but is a fairly complex topic, discussed in more depth in the general for the
-[Free Tier](../../join/free_tier.md) and the [Early Adopter program](../../join/early_adopter.md).
+It offers some interesting features (e.g., a user can securely reuse an existing account),
+but is a fairly complex topic, discussed in more depth on the [Free Trial](../../join/free_trial.md) page.
 
 The following code snippet shows how to log in via OIDC authentication:
 

--- a/join/free_trial.md
+++ b/join/free_trial.md
@@ -2,15 +2,15 @@
 # 30 Day free trial of openEO Platform 
 
 Registration to the platform and management of your user account happens via the [EOPlaza](https://portal.terrascope.be) portal. 
-You will receive a free trial upon first registration which can be started via [this link](https://sso.terrascope.be/auth/realms/terrascope/protocol/openid-connect/auth?client_id=openeoplatform&redirect_uri=https://portal.terrascope.be/dashboard&state=0%2F95954a95-1968-4a64-8b88-fef0f47936fb&response_type=code&scope=openid) 
+You will receive a free trial upon first registration which can be started via [this link](https://sso.terrascope.be/auth/realms/terrascope/protocol/openid-connect/auth?client_id=openeoplatform&redirect_uri=https://portal.terrascope.be/dashboard&state=0%2F95954a95-1968-4a64-8b88-fef0f47936fb&response_type=code&scope=openid).
 
-EOPlaza manages your account balance on the platform, free trial users receive 1000 free credits upon registration. Whenever you consume processing resources on openEO platform, credits will be deducted. You can increase the number of credits by a Network of Resources request, or acquiring them directly on EOPlaza.
+EOPlaza manages your account balance on the platform, free trial users receive 1000 free credits upon registration. Whenever you consume processing resources on openEO Platform, credits will be deducted. You can increase the number of credits by a [Network of Resources](https://openeo.cloud/esa-network-of-resources-funding/) request, or acquiring them directly on EOPlaza.
 
 The registration link takes you through 2 steps that are described in detail below.
 
 ## Preamble: Registration and Login (Authentication)
 
-To register for openEO platform,
+To register for openEO Platform,
 you usually do not need to pick a username and invent a new password. 
 Instead, we rely on the authentication and authorization service
 [EGI check-in](https://www.egi.eu/services/check-in/),
@@ -21,14 +21,14 @@ or other commonly used (social) platforms such as Google, GitHub, Facebook or Li
 ::: tip Some background on Security & Privacy
 This procedure has important advantages for our users:
 
-- Neither openEO platform nor the EGI Foundation see, handle or store your password.
+- Neither openEO Platform nor the EGI Foundation see, handle or store your password.
   That information is only exchanged directly with your institution or the selected (social) platforms, 
   to minimize the risk of leaking sensitive credentials.
-- openEO platform and EOPlaza only retain minimal information about its users,
-  such as an email address and a few more general attributes. 
+- openEO Platform and EOPlaza only retain minimal information about its users,
+  such as an email address and a few more general attributes.
 - No need to set up and remember yet another username and password.
 
-For further details, you can check the privacy policy of [openEO platform](https://openeo.cloud/privacy-policy) and [EOPlaza](https://vito.be/en/privacy-policy).
+For further details, you can check the privacy policy of [openEO Platform](https://openeo.cloud/privacy-policy) and [EOPlaza](https://vito.be/en/privacy-policy).
 :::
 
 ## Step 1: Connect an existing account
@@ -87,7 +87,7 @@ If you have any questions about the enrollment to openEO Platform or the free tr
 please [contact us](https://openeo.cloud/contact/).
 
 
-## Working with openEO platform
+## Working with openEO Platform
 
 After you've been registered on openEO Platform, you can start working with
 the platform through any of the clients. With all clients you will need to connect to


### PR DESCRIPTION
Pull request to remove early adopter registration page from the navigation.

Shall we immediately also clean up the page itself? Any chance of having broken links?